### PR TITLE
Update build.sbt entry for tuco-core in docs

### DIFF
--- a/modules/docs/src/main/tut/index.md
+++ b/modules/docs/src/main/tut/index.md
@@ -25,7 +25,7 @@ The current development version is **{{site.tucoVersion}}** for **Scala {{site.s
 Add the dependency to your `build.sbt` thus:
 
 ```scala
-libraryDependencies += "org.tpolecat" %% "tuco"       % "{{site.tucoVersion}}" // either this
+libraryDependencies += "org.tpolecat" %% "tuco-core"  % "{{site.tucoVersion}}" // either this
 libraryDependencies += "org.tpolecat" %% "tuco-shell" % "{{site.tucoVersion}}" // or this, which includes the shell API
 ```
 


### PR DESCRIPTION
I went to go pull down tuco and was getting an error. After a brief investigation I found I needed to change the name to `tuco-core` from `tuco` and it worked.