### PR TITLE
oops, can't depend on F[_]: ContextShift yet

### DIFF
--- a/modules/docs/src/main/tut/docs/guessing-game.md
+++ b/modules/docs/src/main/tut/docs/guessing-game.md
@@ -12,7 +12,6 @@ For our next **Tuco** program we will build a telnet server that plays a guessin
 ```tut:silent
 import scala.util.{ Random, Try, Success, Failure }
 import cats._, cats.implicits._, cats.kernel.Comparison._, cats.effect._
-import scala.concurrent.ExecutionContext
 import tuco._, Tuco._
 ```
 
@@ -73,9 +72,6 @@ def game(r: Random): SessionIO[Unit] =
 Our game is fully implemented and we can define the server config.
 
 ```tut:silent
-// We get this for free when using `IOApp`, as we do in the examples project.
-implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-
 val conf = Config[IO](game(new Random(123L)), 6666)
 ```
 

--- a/modules/docs/src/main/tut/docs/hello-world.md
+++ b/modules/docs/src/main/tut/docs/hello-world.md
@@ -13,7 +13,6 @@ The first thing we need to do is bring **Tuco** types and constructors into scop
 
 ```tut:silent
 import cats._, cats.implicits._, cats.effect._
-import scala.concurrent.ExecutionContext
 import tuco._, Tuco._
 ```
 
@@ -31,9 +30,6 @@ val hello: SessionIO[Unit] =
 To complete the specification of our telnet server we construct a `Config` with our behavior and various server options. The defaults are reasonable so we will just provide a port, which is the only required option.
 
 ```tut:silent
-// We get this for free when using `IOApp`, as we do in the examples project.
-implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-
 val conf = Config[IO](hello, 6666)
 ```
 

--- a/modules/docs/src/main/tut/docs/todo-list.md
+++ b/modules/docs/src/main/tut/docs/todo-list.md
@@ -16,7 +16,6 @@ First let's deal with imports. Note that we're importing the contents `com.monov
 ```tut:silent
 import com.monovore.decline.{ Command => Cmd, _ }
 import cats._, cats.implicits._, cats.effect._
-import scala.concurrent.ExecutionContext
 import tuco._, Tuco._
 import tuco.shell._
 ```
@@ -221,9 +220,6 @@ val todo: SessionIO[Unit] =
 Our configuration is as before.
 
 ```tut:silent
-// We get this for free when using `IOApp`, as we do in the examples project.
-implicit val ioContextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-
 val conf = Config[IO](todo, 6666)
 ```
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1"
+version in ThisBuild := "0.4.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+version in ThisBuild := "0.4.1"


### PR DESCRIPTION
I need `F` to be `ConnectionIO` in some other code so this won't work. Tagless will make this less terrible.